### PR TITLE
treat *DB differently on WithContext

### DIFF
--- a/pg/db.go
+++ b/pg/db.go
@@ -209,10 +209,15 @@ func (db *DB) Commit() error {
 // WithContext calls the given db WithContext method and returns a DB with the new pg.DB
 // If a transaction is passed as argument it is just returned without setting a new ctx
 func WithContext(ctx context.Context, db interfaces.DB) interfaces.DB {
-	if _, ok := db.(interface{ Rollback() error }); ok {
-		// is actually a transaction: noop
+	// the cases on if/else are actually transactions: noop
+	if sdb, ok := db.(*DB); ok {
+		if sdb.tx != nil {
+			return db
+		}
+	} else if _, ok := db.(interface{ Rollback() error }); ok {
 		return db
 	}
+
 	return &DB{
 		inner: db.WithContext(ctx),
 	}


### PR DESCRIPTION
I noticed that WithContext wasn't working in my project. The reason why is because on WithContext the test to see if `interfaces.DB` is a transaction is trying to cast it to `interface{ Rollback() error }`.

The problem is that `*DB` of extensions has the method `Rollback() error`. So even though it has a Rollback(), it is not necessarily a transaction. 

So I check if it is a transaction by trying to cast it to `*DB` and asserting that `db.tx` is not nil. 