### PR TITLE
Update github.com/go-pg/pg version in Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "github.com/go-pg/pg"
-  version = "6.11.2"
+  version = "~6.12.0"
 
 [[constraint]]
   name = "github.com/go-redis/redis"


### PR DESCRIPTION
I was trying to use the pg extensions in my project and I couldn't build the project, because when I used dep ensure the downloaded version was 6.14 and It had incpompatibilies issues with the extensions implementation.

I tried other versions and found out that up to the 6.13 go-pg version it was working, but it had another incompatibility issue with Jaeger this time.

So the latest safe to run version is 6.12.x

To fix the problem locally I had to use an [[override]] clause in my Gopkg.toml, but I think it would be better if the extensions project had the proper version of the dependency, or includes an warning in the README on how to fix the problem.