### PR TITLE
Moving generic tracing to tracing instead of jaeger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -790,11 +790,8 @@
   digest = "1:c80894778314c7fb90d94a5ab925214900e1341afeddc953cda7398b8cdcd006"
   name = "gopkg.in/mgo.v2"
   packages = [
-    ".",
     "bson",
     "internal/json",
-    "internal/sasl",
-    "internal/scram",
   ]
   pruneopts = ""
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
@@ -873,7 +870,6 @@
     "github.com/uber/jaeger-client-go/config",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
-    "gopkg.in/mgo.v2",
     "gopkg.in/mgo.v2/bson",
     "gopkg.in/mgutz/dat.v2/dat",
     "gopkg.in/olivere/elastic.v5",

--- a/dat/execer.go
+++ b/dat/execer.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"time"
 
-	jaeger "github.com/topfreegames/extensions/jaeger/dat"
+	tracing "github.com/topfreegames/extensions/tracing/dat"
 	"gopkg.in/mgutz/dat.v2/dat"
 )
 
@@ -75,7 +75,7 @@ func (jex *Execer) Exec() (*dat.Result, error) {
 		return result, err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		result, err = jex.ex.Exec()
 		return err
 	})
@@ -90,7 +90,7 @@ func (jex *Execer) QueryScalar(destinations ...interface{}) error {
 		return err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		err = jex.ex.QueryScalar(destinations...)
 		return err
 	})
@@ -106,7 +106,7 @@ func (jex *Execer) QuerySlice(dest interface{}) error {
 		return err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		err = jex.ex.QuerySlice(dest)
 		return err
 	})
@@ -121,7 +121,7 @@ func (jex *Execer) QueryStruct(dest interface{}) error {
 		return err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		err = jex.ex.QueryStruct(dest)
 		return err
 	})
@@ -136,7 +136,7 @@ func (jex *Execer) QueryStructs(dest interface{}) error {
 		return err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		err = jex.ex.QueryStructs(dest)
 		return err
 	})
@@ -152,7 +152,7 @@ func (jex *Execer) QueryObject(dest interface{}) error {
 		return err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		err = jex.ex.QueryObject(dest)
 		return err
 	})
@@ -169,7 +169,7 @@ func (jex *Execer) QueryJSON() ([]byte, error) {
 		return result, err
 	}
 
-	jaeger.Trace(jex.ctx, fullSQL, func() error {
+	tracing.Trace(jex.ctx, fullSQL, func() error {
 		result, err = jex.ex.QueryJSON()
 		return err
 	})

--- a/echo/echo.go
+++ b/echo/echo.go
@@ -24,7 +24,7 @@ package echo
 
 import (
 	"github.com/labstack/echo"
-	jecho "github.com/topfreegames/extensions/jaeger/echo"
+	techo "github.com/topfreegames/extensions/tracing/echo"
 )
 
 // Echo is the top-level framework instance.
@@ -35,6 +35,6 @@ type Echo struct {
 // New creates an instance of Echo.
 func New() *Echo {
 	app := echo.New()
-	jecho.Instrument(app)
+	techo.Instrument(app)
 	return &Echo{app}
 }

--- a/gorp/gorp.go
+++ b/gorp/gorp.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/go-gorp/gorp"
 	"github.com/topfreegames/extensions/gorp/interfaces"
-	jgorp "github.com/topfreegames/extensions/jaeger/gorp"
+	tgorp "github.com/topfreegames/extensions/tracing/gorp"
 )
 
 // New wraps and instruments an existing connection to a database
@@ -58,7 +58,7 @@ func (d *Database) Begin() (interfaces.Transaction, error) {
 	var inner *gorp.Transaction
 	var err error
 
-	jgorp.Trace(d.ctx, d.executor.name, "BEGIN", func() error {
+	tgorp.Trace(d.ctx, d.executor.name, "BEGIN", func() error {
 		inner, err = d.Inner().Begin()
 		return err
 	})
@@ -100,7 +100,7 @@ func (t *Transaction) WithContext(ctx context.Context) gorp.SqlExecutor {
 func (t *Transaction) Commit() error {
 	var err error
 
-	jgorp.Trace(t.ctx, t.executor.name, "COMMIT", func() error {
+	tgorp.Trace(t.ctx, t.executor.name, "COMMIT", func() error {
 		err = t.Inner().Commit()
 		return err
 	})
@@ -112,7 +112,7 @@ func (t *Transaction) Commit() error {
 func (t *Transaction) Rollback() error {
 	var err error
 
-	jgorp.Trace(t.ctx, t.executor.name, "ROLLBACK", func() error {
+	tgorp.Trace(t.ctx, t.executor.name, "ROLLBACK", func() error {
 		err = t.Inner().Rollback()
 		return err
 	})
@@ -147,7 +147,7 @@ func (e *executor) Get(i interface{}, keys ...interface{}) (interface{}, error) 
 
 	query := fmt.Sprintf("SELECT <type:%T keys:%v>", i, keys)
 
-	jgorp.Trace(e.ctx, e.name, query, func() error {
+	tgorp.Trace(e.ctx, e.name, query, func() error {
 		result, err = e.inner.Get(i, keys...)
 		return err
 	})
@@ -162,7 +162,7 @@ func (e *executor) Insert(list ...interface{}) error {
 	types := types(list)
 	query := fmt.Sprintf("MULTI-INSERT <objects:%v>", types)
 
-	jgorp.Trace(e.ctx, e.name, query, func() error {
+	tgorp.Trace(e.ctx, e.name, query, func() error {
 		err = e.inner.Insert(list...)
 		return err
 	})
@@ -178,7 +178,7 @@ func (e *executor) Update(list ...interface{}) (int64, error) {
 	types := types(list)
 	query := fmt.Sprintf("MULTI-UPDATE <objects:%v>", types)
 
-	jgorp.Trace(e.ctx, e.name, query, func() error {
+	tgorp.Trace(e.ctx, e.name, query, func() error {
 		result, err = e.inner.Update(list...)
 		return err
 	})
@@ -194,7 +194,7 @@ func (e *executor) Delete(list ...interface{}) (int64, error) {
 	types := types(list)
 	query := fmt.Sprintf("MULTI-DELETE <objects:%v>", types)
 
-	jgorp.Trace(e.ctx, e.name, query, func() error {
+	tgorp.Trace(e.ctx, e.name, query, func() error {
 		result, err = e.inner.Delete(list...)
 		return err
 	})
@@ -207,7 +207,7 @@ func (e *executor) Exec(query string, args ...interface{}) (sql.Result, error) {
 	var result sql.Result
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.Exec(query, args...)
 		return err
 	})
@@ -220,7 +220,7 @@ func (e *executor) Select(i interface{}, query string, args ...interface{}) ([]i
 	var result []interface{}
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.Select(i, query, args...)
 		return err
 	})
@@ -233,7 +233,7 @@ func (e *executor) SelectInt(query string, args ...interface{}) (int64, error) {
 	var result int64
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectInt(query, args...)
 		return err
 	})
@@ -246,7 +246,7 @@ func (e *executor) SelectNullInt(query string, args ...interface{}) (sql.NullInt
 	var result sql.NullInt64
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectNullInt(query, args...)
 		return err
 	})
@@ -259,7 +259,7 @@ func (e *executor) SelectFloat(query string, args ...interface{}) (float64, erro
 	var result float64
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectFloat(query, args...)
 		return err
 	})
@@ -272,7 +272,7 @@ func (e *executor) SelectNullFloat(query string, args ...interface{}) (sql.NullF
 	var result sql.NullFloat64
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectNullFloat(query, args...)
 		return err
 	})
@@ -285,7 +285,7 @@ func (e *executor) SelectStr(query string, args ...interface{}) (string, error) 
 	var result string
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectStr(query, args...)
 		return err
 	})
@@ -298,7 +298,7 @@ func (e *executor) SelectNullStr(query string, args ...interface{}) (sql.NullStr
 	var result sql.NullString
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.SelectNullStr(query, args...)
 		return err
 	})
@@ -310,7 +310,7 @@ func (e *executor) SelectNullStr(query string, args ...interface{}) (sql.NullStr
 func (e *executor) SelectOne(holder interface{}, query string, args ...interface{}) error {
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		err = e.inner.SelectOne(holder, query, args...)
 		return err
 	})
@@ -322,7 +322,7 @@ func (e *executor) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	var result *sql.Rows
 	var err error
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result, err = e.inner.Query(query, args...)
 		return err
 	})
@@ -333,7 +333,7 @@ func (e *executor) Query(query string, args ...interface{}) (*sql.Rows, error) {
 func (e *executor) QueryRow(query string, args ...interface{}) *sql.Row {
 	var result *sql.Row
 
-	jgorp.Trace(e.ctx, e.name, format(query, args), func() error {
+	tgorp.Trace(e.ctx, e.name, format(query, args), func() error {
 		result = e.inner.QueryRow(query, args...)
 		return nil
 	})

--- a/http/http.go
+++ b/http/http.go
@@ -25,7 +25,7 @@ package http
 import (
 	"net/http"
 
-	jaeger "github.com/topfreegames/extensions/jaeger/http"
+	tracing "github.com/topfreegames/extensions/tracing/http"
 )
 
 // New creates and instruments an HTTP client
@@ -58,7 +58,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
-	jaeger.Trace(req, func() error {
+	tracing.Trace(req, func() error {
 		resp, err = t.inner.RoundTrip(req)
 		return err
 	})

--- a/middleware/jaeger.go
+++ b/middleware/jaeger.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/opentracing/opentracing-go"
-	"github.com/topfreegames/extensions/jaeger"
+	"github.com/topfreegames/extensions/tracing"
 )
 
-// Jaeger is a middleware for jaeger tracing
+// Jaeger is a middleware for tracing
 func Jaeger() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,7 +52,7 @@ func Jaeger() func(next http.Handler) http.Handler {
 
 			span := opentracing.StartSpan(operationName, reference, tags)
 			defer span.Finish()
-			defer jaeger.LogPanic(span)
+			defer tracing.LogPanic(span)
 			defer func() {
 				status := GetStatusCode(w)
 				span.SetTag("http.status_code", status)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
-	jaeger "github.com/topfreegames/extensions/jaeger/mongo"
 	"github.com/topfreegames/extensions/mongo/interfaces"
+	tracing "github.com/topfreegames/extensions/tracing/mongo"
 )
 
 //Mongo holds the mongo database and connection
@@ -69,7 +69,7 @@ func (m *Mongo) Run(cmd interface{}, result interface{}) error {
 	database := m.db.Name
 	args := formatArgs(cmd)
 
-	jaeger.Trace(m.ctx, database, database, "runCommand", args, func() error {
+	tracing.Trace(m.ctx, database, database, "runCommand", args, func() error {
 		err = m.db.With(session).Run(cmd, result)
 		return err
 	})
@@ -131,7 +131,7 @@ func (c *Collection) Insert(docs ...interface{}) error {
 	collection := c.collection.FullName
 	args := formatArgs(docs)
 
-	jaeger.Trace(c.ctx, database, collection, "insert", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "insert", args, func() error {
 		err = c.collection.Insert(docs...)
 		return err
 	})
@@ -148,7 +148,7 @@ func (c *Collection) UpsertId(id interface{}, update interface{}) (*mgo.ChangeIn
 	collection := c.collection.FullName
 	args := formatArgs(bson.D{{Name: "_id", Value: id}}, update)
 
-	jaeger.Trace(c.ctx, database, collection, "updateOne", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "updateOne", args, func() error {
 		result, err = c.collection.UpsertId(id, update)
 		return err
 	})
@@ -165,7 +165,7 @@ func (c *Collection) Upsert(selector interface{}, update interface{}) (*mgo.Chan
 	collection := c.collection.FullName
 	args := formatArgs(selector, update)
 
-	jaeger.Trace(c.ctx, database, collection, "updateOne", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "updateOne", args, func() error {
 		result, err = c.collection.Upsert(selector, update)
 		return err
 	})
@@ -181,7 +181,7 @@ func (c *Collection) RemoveId(id interface{}) error {
 	collection := c.collection.FullName
 	args := formatArgs(bson.D{{Name: "_id", Value: id}})
 
-	jaeger.Trace(c.ctx, database, collection, "remove", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "remove", args, func() error {
 		err = c.collection.RemoveId(id)
 		return err
 	})
@@ -197,7 +197,7 @@ func (c *Collection) Remove(selector interface{}) error {
 	collection := c.collection.FullName
 	args := formatArgs(selector)
 
-	jaeger.Trace(c.ctx, database, collection, "remove", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "remove", args, func() error {
 		err = c.collection.Remove(selector)
 		return err
 	})
@@ -214,7 +214,7 @@ func (c *Collection) RemoveAll(selector interface{}) (*mgo.ChangeInfo, error) {
 	collection := c.collection.FullName
 	args := formatArgs(selector)
 
-	jaeger.Trace(c.ctx, database, collection, "remove", args, func() error {
+	tracing.Trace(c.ctx, database, collection, "remove", args, func() error {
 		result, err = c.collection.RemoveAll(selector)
 		return err
 	})
@@ -252,7 +252,7 @@ func (b *Bulk) Run() (*mgo.BulkResult, error) {
 	collection := b.collection.FullName
 	args := ""
 
-	jaeger.Trace(b.ctx, database, collection, "bulkRun", args, func() error {
+	tracing.Trace(b.ctx, database, collection, "bulkRun", args, func() error {
 		result, err = b.bulk.Run()
 		return err
 	})
@@ -292,7 +292,7 @@ func (q *Query) Iter() interfaces.Iter {
 func (q *Query) All(result interface{}) error {
 	var err error
 
-	jaeger.Trace(q.ctx, q.database, q.prefix, "find", q.args, func() error {
+	tracing.Trace(q.ctx, q.database, q.prefix, "find", q.args, func() error {
 		err = q.query.All(result)
 		return err
 	})
@@ -304,7 +304,7 @@ func (q *Query) All(result interface{}) error {
 func (q *Query) One(result interface{}) error {
 	var err error
 
-	jaeger.Trace(q.ctx, q.database, q.prefix, "findOne", q.args, func() error {
+	tracing.Trace(q.ctx, q.database, q.prefix, "findOne", q.args, func() error {
 		err = q.query.One(result)
 		return err
 	})

--- a/mqtt/mqtt.go
+++ b/mqtt/mqtt.go
@@ -26,8 +26,8 @@ import (
 	"context"
 
 	"github.com/eclipse/paho.mqtt.golang"
-	jaeger "github.com/topfreegames/extensions/jaeger/mqtt"
 	"github.com/topfreegames/extensions/mqtt/interfaces"
+	tracing "github.com/topfreegames/extensions/tracing/mqtt"
 )
 
 // Client wraps an MQTT client
@@ -44,6 +44,7 @@ func NewClient(opts *mqtt.ClientOptions) interfaces.Client {
 	return &Client{ctx, inner, opts}
 }
 
+// WithContext wraps the client with a context
 func (c *Client) WithContext(ctx context.Context) interfaces.Client {
 	if ctx == nil {
 		panic("Context must be non-nil")
@@ -55,7 +56,7 @@ func (c *Client) WithContext(ctx context.Context) interfaces.Client {
 func (c *Client) Publish(topic string, qos byte, retained bool, payload interface{}) mqtt.Token {
 	var token mqtt.Token
 
-	jaeger.Trace(c.ctx, "PUBLISH", topic, qos, c.opts.PingTimeout, func() mqtt.Token {
+	tracing.Trace(c.ctx, "PUBLISH", topic, qos, c.opts.PingTimeout, func() mqtt.Token {
 		token = c.inner.Publish(topic, qos, retained, payload)
 		return token
 	})
@@ -67,7 +68,7 @@ func (c *Client) Publish(topic string, qos byte, retained bool, payload interfac
 func (c *Client) Subscribe(topic string, qos byte, callback mqtt.MessageHandler) mqtt.Token {
 	var token mqtt.Token
 
-	jaeger.Trace(c.ctx, "SUBSCRIBE", topic, qos, c.opts.PingTimeout, func() mqtt.Token {
+	tracing.Trace(c.ctx, "SUBSCRIBE", topic, qos, c.opts.PingTimeout, func() mqtt.Token {
 		token = c.inner.Subscribe(topic, qos, callback)
 		return token
 	})

--- a/pg/db.go
+++ b/pg/db.go
@@ -29,8 +29,8 @@ import (
 
 	pg "github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
-	jaeger "github.com/topfreegames/extensions/jaeger/pg"
 	"github.com/topfreegames/extensions/pg/interfaces"
+	tracing "github.com/topfreegames/extensions/tracing/pg"
 )
 
 // DB implements the orm.DB interface with a few tweaks for tracing
@@ -101,12 +101,12 @@ func (db *DB) Model(model ...interface{}) *orm.Query {
 	return db.inner.Model(model...).DB(db)
 }
 
-// Exec wraps the inner db or tx Exec call in a jaeger trace
+// Exec wraps the inner db or tx Exec call in a tracing trace
 // If a tx is available it will be used
 func (db *DB) Exec(query interface{}, params ...interface{}) (orm.Result, error) {
 	var res orm.Result
 	var err error
-	jaeger.Trace(db.inner.Context(), query, func() error {
+	tracing.Trace(db.inner.Context(), query, func() error {
 		if db.tx != nil {
 			res, err = db.tx.Exec(query, params...)
 		} else {
@@ -117,12 +117,12 @@ func (db *DB) Exec(query interface{}, params ...interface{}) (orm.Result, error)
 	return res, err
 }
 
-// ExecOne wraps the inner db or tx ExecOne call in a jaeger trace
+// ExecOne wraps the inner db or tx ExecOne call in a tracing trace
 // If a tx is available it will be used
 func (db *DB) ExecOne(query interface{}, params ...interface{}) (orm.Result, error) {
 	var res orm.Result
 	var err error
-	jaeger.Trace(db.inner.Context(), query, func() error {
+	tracing.Trace(db.inner.Context(), query, func() error {
 		if db.tx != nil {
 			res, err = db.tx.ExecOne(query, params...)
 		} else {
@@ -133,12 +133,12 @@ func (db *DB) ExecOne(query interface{}, params ...interface{}) (orm.Result, err
 	return res, err
 }
 
-// Query wraps the inner db or tx Query call in a jaeger trace
+// Query wraps the inner db or tx Query call in a tracing trace
 // If a tx is available it will be used
 func (db *DB) Query(model, query interface{}, params ...interface{}) (orm.Result, error) {
 	var res orm.Result
 	var err error
-	jaeger.Trace(db.inner.Context(), query, func() error {
+	tracing.Trace(db.inner.Context(), query, func() error {
 		if db.tx != nil {
 			res, err = db.tx.Query(model, query, params...)
 		} else {
@@ -149,12 +149,12 @@ func (db *DB) Query(model, query interface{}, params ...interface{}) (orm.Result
 	return res, err
 }
 
-// QueryOne wraps the inner db or tx QueryOne call in a jaeger trace
+// QueryOne wraps the inner db or tx QueryOne call in a tracing trace
 // If a tx is available it will be used
 func (db *DB) QueryOne(model, query interface{}, params ...interface{}) (orm.Result, error) {
 	var res orm.Result
 	var err error
-	jaeger.Trace(db.inner.Context(), query, func() error {
+	tracing.Trace(db.inner.Context(), query, func() error {
 		if db.tx != nil {
 			res, err = db.tx.QueryOne(model, query, params...)
 		} else {
@@ -165,22 +165,22 @@ func (db *DB) QueryOne(model, query interface{}, params ...interface{}) (orm.Res
 	return res, err
 }
 
-// Begin wraps the inner db Begin call in a jaeger trace
+// Begin wraps the inner db Begin call in a tracing trace
 func (db *DB) Begin() (*pg.Tx, error) {
 	var tx *pg.Tx
 	var err error
-	jaeger.Trace(db.inner.Context(), "BEGIN", func() error {
+	tracing.Trace(db.inner.Context(), "BEGIN", func() error {
 		tx, err = db.inner.Begin()
 		return err
 	})
 	return tx, err
 }
 
-// Rollback wraps the inner db Rollback call in a jaeger trace
+// Rollback wraps the inner db Rollback call in a tracing trace
 // It returns an error if no tx is available in the current db
 func (db *DB) Rollback() error {
 	var err error
-	jaeger.Trace(db.inner.Context(), "ROLLBACK", func() error {
+	tracing.Trace(db.inner.Context(), "ROLLBACK", func() error {
 		if db.tx != nil {
 			err = db.tx.Rollback()
 		} else {
@@ -191,11 +191,11 @@ func (db *DB) Rollback() error {
 	return err
 }
 
-// Commit wraps the inner db Commit call in a jaeger trace
+// Commit wraps the inner db Commit call in a tracing trace
 // It returns an error if no tx is available in the current db
 func (db *DB) Commit() error {
 	var err error
-	jaeger.Trace(db.inner.Context(), "COMMIT", func() error {
+	tracing.Trace(db.inner.Context(), "COMMIT", func() error {
 		if db.tx != nil {
 			err = db.tx.Commit()
 		} else {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -30,8 +30,8 @@ import (
 	"github.com/bsm/redis-lock"
 	"github.com/go-redis/redis"
 	"github.com/spf13/viper"
-	jredis "github.com/topfreegames/extensions/jaeger/redis"
 	"github.com/topfreegames/extensions/redis/interfaces"
+	tredis "github.com/topfreegames/extensions/tracing/redis"
 )
 
 // Client identifies uniquely one redis client with a pool of connections
@@ -81,13 +81,13 @@ func NewClient(prefix string, config *viper.Viper, ifaces ...interface{}) (*Clie
 	return client, nil
 }
 
-// Trace creates a Redis client that sends traces to Jaeger
+// Trace creates a Redis client that sends traces to tracing
 func (c *Client) Trace(ctx context.Context) interfaces.RedisClient {
 	if c.TraceWrapper != nil {
 		return c.TraceWrapper.WithContext(ctx, c.Client)
 	}
 	copy := c.Client.WithContext(ctx)
-	jredis.Instrument(copy)
+	tredis.Instrument(copy)
 	return copy
 }
 

--- a/tracing/echo/instrument.go
+++ b/tracing/echo/instrument.go
@@ -29,10 +29,10 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine"
 	"github.com/opentracing/opentracing-go"
-	"github.com/topfreegames/extensions/jaeger"
+	"github.com/topfreegames/extensions/tracing"
 )
 
-// Instrument adds Jaeger instrumentation on an Echo app
+// Instrument adds tracing instrumentation on an Echo app
 func Instrument(app *echo.Echo) {
 	middleware := makeMiddleware()
 	app.Use(middleware)
@@ -65,7 +65,7 @@ func makeMiddleware() func(echo.HandlerFunc) echo.HandlerFunc {
 
 			span := opentracing.StartSpan(operationName, reference, tags)
 			defer span.Finish()
-			defer jaeger.LogPanic(span)
+			defer tracing.LogPanic(span)
 
 			ctx := c.StdContext()
 			ctx = opentracing.ContextWithSpan(ctx, span)
@@ -74,7 +74,7 @@ func makeMiddleware() func(echo.HandlerFunc) echo.HandlerFunc {
 			err := next(c)
 			if err != nil {
 				message := err.Error()
-				jaeger.LogError(span, message)
+				tracing.LogError(span, message)
 			}
 
 			response := c.Response()

--- a/tracing/redis/instrument.go
+++ b/tracing/redis/instrument.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/opentracing/opentracing-go"
-	"github.com/topfreegames/extensions/jaeger"
+	"github.com/topfreegames/extensions/tracing"
 )
 
-// Instrument adds Jaeger instrumentation on a Redis client
+// Instrument adds tracing instrumentation on a Redis client
 func Instrument(client *redis.Client) {
 	middleware := makeMiddleware(client)
 	client.WrapProcess(middleware)
@@ -60,12 +60,12 @@ func makeMiddleware(client *redis.Client) func(old func(cmd redis.Cmder) error) 
 
 			span := opentracing.StartSpan(operationName, reference, tags)
 			defer span.Finish()
-			defer jaeger.LogPanic(span)
+			defer tracing.LogPanic(span)
 
 			err := old(cmd)
 			if err != nil {
 				message := err.Error()
-				jaeger.LogError(span, message)
+				tracing.LogError(span, message)
 			}
 
 			return err
@@ -102,12 +102,12 @@ func makeMiddlewarePipe(client *redis.Client) func(old func(cmds []redis.Cmder) 
 
 			span := opentracing.StartSpan(operationName, reference, tags)
 			defer span.Finish()
-			defer jaeger.LogPanic(span)
+			defer tracing.LogPanic(span)
 
 			err := old(cmds)
 			if err != nil {
 				message := err.Error()
-				jaeger.LogError(span, message)
+				tracing.LogError(span, message)
 			}
 
 			return err

--- a/util/version.go
+++ b/util/version.go
@@ -23,4 +23,4 @@
 package util
 
 //Version identifies extensions package version
-const Version = "6.4.5"
+const Version = "7.0.0"


### PR DESCRIPTION
Most of the jaeger instrumentation is actually a generic opentracing-compatible instrumentation that isn't specific to jaeger. So I think that moving this logic to a separate package helps understanding its responsibilities, at the same time enabling the reuse for other opentracing-compatible solutions, such as Elastic APM.

@cscatolini This is more of a quality of life change and shouldn't break external users of the library, but  it's probably safer to increment the major version