### PR TITLE
Add error to PutObject in the s3 interface

### DIFF
--- a/s3/interfaces/s3.go
+++ b/s3/interfaces/s3.go
@@ -28,5 +28,5 @@ import "net/http"
 type S3 interface {
 	DeleteObject(key string) error
 	PutObjectRequest(key, acl string) (string, http.Header, error)
-	PutObject(key string, body *[]byte)
+	PutObject(key string, body *[]byte) error
 }

--- a/s3/mocks/s3.go
+++ b/s3/mocks/s3.go
@@ -64,9 +64,11 @@ func (mr *MockS3MockRecorder) PutObjectRequest(key, acl interface{}) *gomock.Cal
 }
 
 // PutObject mocks base method
-func (m *MockS3) PutObject(key string, body *[]byte) {
+func (m *MockS3) PutObject(key string, body *[]byte) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PutObject", key, body)
+	ret := m.ctrl.Call(m, "PutObject", key, body)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // PutObject indicates an expected call of PutObject


### PR DESCRIPTION
In the last pull request, I made some in the s3 interface, but I forgot to return the error in the PutObjec method. This pull request corrects that.