### PR TITLE
Add method PutObjectInput to s3

### DIFF
--- a/s3/interfaces/s3.go
+++ b/s3/interfaces/s3.go
@@ -22,11 +22,15 @@
 
 package interfaces
 
-import "net/http"
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+	"net/http"
+)
 
 // S3 is the minimum interface a S3Client must implement
 type S3 interface {
 	DeleteObject(key string) error
 	PutObjectRequest(key, acl string) (string, http.Header, error)
 	PutObject(key string, body *[]byte) error
+	PutObjectInput(params *s3.PutObjectInput, body *[]byte) error
 }

--- a/s3/mocks/s3.go
+++ b/s3/mocks/s3.go
@@ -5,6 +5,7 @@
 package mock_interfaces
 
 import (
+	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
 	http "net/http"
 	reflect "reflect"
@@ -75,4 +76,18 @@ func (m *MockS3) PutObject(key string, body *[]byte) error {
 func (mr *MockS3MockRecorder) PutObject(key, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObject", reflect.TypeOf((*MockS3)(nil).PutObject), key, body)
+}
+
+// PutObjectInput mocks base method
+func (m *MockS3) PutObjectInput(params *s3.PutObjectInput, body *[]byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutObjectInput", params, body)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutObjectInput indicates an expected call of PutObjectInput
+func (mr *MockS3MockRecorder) PutObjectInput(params, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObjectInput", reflect.TypeOf((*MockS3)(nil).PutObjectInput), params, body)
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -152,3 +152,20 @@ func (c Client) DeleteObject(key string) error {
 	}
 	return nil
 }
+
+// PutObjectInput puts an object into s3, if params.Bucket or params.Body
+// are equal nil, they will be overwrite
+func (c Client) PutObjectInput(params *s3.PutObjectInput, body *[]byte) error {
+	b := bytes.NewReader(*body)
+	if params.Bucket == nil {
+		params.Bucket = &c.bucket
+	}
+	if params.Body == nil {
+		params.Body = b
+	}
+	_, err := c.client.PutObject(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request creates the PutObjectInput method in the s3 client. With this method, more parameter can be set when adding an object to a bucket.
