### PR TITLE
Kafka prefix

### DIFF
--- a/kafka/kafka_consumer.go
+++ b/kafka/kafka_consumer.go
@@ -59,8 +59,22 @@ func NewConsumer(
 	logger *logrus.Logger,
 	clientOrNil ...interfaces.KafkaConsumerClient,
 ) (*Consumer, error) {
+	return NewConsumerWithPrefix(config, logger, "extensions.kafkaconsumer", clientOrNil...)
+}
+
+// NewConsumerWithPrefix for creating a new Consumer instance
+func NewConsumerWithPrefix(
+	config *viper.Viper,
+	logger *logrus.Logger,
+	prefix string,
+	clientOrNil ...interfaces.KafkaConsumerClient,
+) (*Consumer, error) {
+	subconfig := config.Sub(prefix)
+	if subconfig == nil {
+		subconfig = viper.New()
+	}
 	q := &Consumer{
-		Config:            config,
+		Config:            subconfig,
 		Logger:            logger,
 		messagesReceived:  0,
 		pendingMessagesWG: nil,
@@ -78,23 +92,23 @@ func NewConsumer(
 }
 
 func (q *Consumer) loadConfigurationDefaults() {
-	q.Config.SetDefault("extensions.kafkaconsumer.topics", []string{"com.games.test"})
-	q.Config.SetDefault("extensions.kafkaconsumer.brokers", "localhost:9092")
-	q.Config.SetDefault("extensions.kafkaconsumer.channelSize", 100)
-	q.Config.SetDefault("extensions.kafkaconsumer.group", "test")
-	q.Config.SetDefault("extensions.kafkaconsumer.sessionTimeout", 6000)
-	q.Config.SetDefault("extensions.kafkaconsumer.offsetResetStrategy", "latest")
-	q.Config.SetDefault("extensions.kafkaconsumer.handleAllMessagesBeforeExiting", true)
+	q.Config.SetDefault("topics", []string{"com.games.test"})
+	q.Config.SetDefault("brokers", "localhost:9092")
+	q.Config.SetDefault("channelSize", 100)
+	q.Config.SetDefault("group", "test")
+	q.Config.SetDefault("sessionTimeout", 6000)
+	q.Config.SetDefault("offsetResetStrategy", "latest")
+	q.Config.SetDefault("handleAllMessagesBeforeExiting", true)
 }
 
 func (q *Consumer) configure(client interfaces.KafkaConsumerClient) error {
-	q.OffsetResetStrategy = q.Config.GetString("extensions.kafkaconsumer.offsetResetStrategy")
-	q.Brokers = q.Config.GetString("extensions.kafkaconsumer.brokers")
-	q.ConsumerGroup = q.Config.GetString("extensions.kafkaconsumer.group")
-	q.SessionTimeout = q.Config.GetInt("extensions.kafkaconsumer.sessionTimeout")
-	q.Topics = q.Config.GetStringSlice("extensions.kafkaconsumer.topics")
-	q.ChannelSize = q.Config.GetInt("extensions.kafkaconsumer.channelSize")
-	q.HandleAllMessagesBeforeExiting = q.Config.GetBool("extensions.kafkaconsumer.handleAllMessagesBeforeExiting")
+	q.OffsetResetStrategy = q.Config.GetString("offsetResetStrategy")
+	q.Brokers = q.Config.GetString("brokers")
+	q.ConsumerGroup = q.Config.GetString("group")
+	q.SessionTimeout = q.Config.GetInt("sessionTimeout")
+	q.Topics = q.Config.GetStringSlice("topics")
+	q.ChannelSize = q.Config.GetInt("channelSize")
+	q.HandleAllMessagesBeforeExiting = q.Config.GetBool("handleAllMessagesBeforeExiting")
 
 	q.msgChan = make(chan []byte, q.ChannelSize)
 

--- a/kafka/kafka_consumer_test.go
+++ b/kafka/kafka_consumer_test.go
@@ -255,6 +255,22 @@ var _ = Describe("Kafka Extension", func() {
 				Expect(cons.Config.GetString("offsetResetStrategy")).To(Equal("latest"))
 				Expect(cons.Config.GetBool("handleAllMessagesBeforeExiting")).To(BeTrue())
 			})
+
+			It("should read a config with prefix", func() {
+				cnf := viper.New()
+				cnf.Set("test.sessionTimeout", 123)
+				cons, err := NewConsumerWithPrefix(cnf, logger, "test", kafkaConsumerClientMock)
+				Expect(err).NotTo(HaveOccurred())
+				cnf = cons.Config
+				cons.loadConfigurationDefaults()
+
+				Expect(cons.Config.GetStringSlice("topics")).To(Equal([]string{"com.games.test"}))
+				Expect(cons.Config.GetString("brokers")).To(Equal("localhost:9092"))
+				Expect(cons.Config.GetString("group")).To(Equal("test"))
+				Expect(cons.Config.GetInt("sessionTimeout")).To(Equal(123))
+				Expect(cons.Config.GetString("offsetResetStrategy")).To(Equal("latest"))
+				Expect(cons.Config.GetBool("handleAllMessagesBeforeExiting")).To(BeTrue())
+			})
 		})
 
 		Describe("Pending Messages Waiting Group", func() {

--- a/kafka/kafka_consumer_test.go
+++ b/kafka/kafka_consumer_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Kafka Extension", func() {
 			})
 
 			It("should assign partition", func() {
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				startConsuming()
 				defer consumer.StopConsuming()
 				part := kafka.TopicPartition{
@@ -128,7 +128,7 @@ var _ = Describe("Kafka Extension", func() {
 			})
 
 			It("should log error if fails to assign partition", func() {
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				startConsuming()
 				defer consumer.StopConsuming()
 
@@ -149,7 +149,7 @@ var _ = Describe("Kafka Extension", func() {
 			})
 
 			It("should revoke partitions", func() {
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				startConsuming()
 				defer consumer.StopConsuming()
 				part := kafka.TopicPartition{
@@ -165,7 +165,7 @@ var _ = Describe("Kafka Extension", func() {
 			})
 
 			It("should stop loop if fails to revoke partitions", func() {
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				startConsuming()
 				defer consumer.StopConsuming()
 				part := kafka.TopicPartition{
@@ -182,7 +182,7 @@ var _ = Describe("Kafka Extension", func() {
 			})
 
 			It("should receive message", func() {
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				startConsuming()
 				defer consumer.StopConsuming()
 				part := kafka.TopicPartition{
@@ -245,14 +245,15 @@ var _ = Describe("Kafka Extension", func() {
 				cnf := viper.New()
 				cons, err := NewConsumer(cnf, logger, kafkaConsumerClientMock)
 				Expect(err).NotTo(HaveOccurred())
+				cnf = cons.Config
 				cons.loadConfigurationDefaults()
 
-				Expect(cnf.GetStringSlice("extensions.kafkaconsumer.topics")).To(Equal([]string{"com.games.test"}))
-				Expect(cnf.GetString("extensions.kafkaconsumer.brokers")).To(Equal("localhost:9092"))
-				Expect(cnf.GetString("extensions.kafkaconsumer.group")).To(Equal("test"))
-				Expect(cnf.GetInt("extensions.kafkaconsumer.sessionTimeout")).To(Equal(6000))
-				Expect(cnf.GetString("extensions.kafkaconsumer.offsetResetStrategy")).To(Equal("latest"))
-				Expect(cnf.GetBool("extensions.kafkaconsumer.handleAllMessagesBeforeExiting")).To(BeTrue())
+				Expect(cons.Config.GetStringSlice("topics")).To(Equal([]string{"com.games.test"}))
+				Expect(cons.Config.GetString("brokers")).To(Equal("localhost:9092"))
+				Expect(cons.Config.GetString("group")).To(Equal("test"))
+				Expect(cons.Config.GetInt("sessionTimeout")).To(Equal(6000))
+				Expect(cons.Config.GetString("offsetResetStrategy")).To(Equal("latest"))
+				Expect(cons.Config.GetBool("handleAllMessagesBeforeExiting")).To(BeTrue())
 			})
 		})
 
@@ -267,7 +268,7 @@ var _ = Describe("Kafka Extension", func() {
 			It("should receive kafka.AssignedPartitions and be ready", func() {
 				go consumer.ConsumeLoop()
 				defer consumer.StopConsuming()
-				topic := consumer.Config.GetStringSlice("extensions.kafkaconsumer.topics")[0]
+				topic := consumer.Config.GetStringSlice("topics")[0]
 				part := kafka.TopicPartition{
 					Topic:     &topic,
 					Partition: 1,

--- a/kafka/kafka_producer.go
+++ b/kafka/kafka_producer.go
@@ -55,8 +55,12 @@ func NewProducerWithPrefix(
 	prefix string,
 	clientOrNil ...interfaces.KafkaProducerClient,
 ) (*Producer, error) {
+	subconfig := config.Sub(prefix)
+	if subconfig == nil {
+		subconfig = viper.New()
+	}
 	q := &Producer{
-		Config: config.Sub(prefix),
+		Config: subconfig,
 		Logger: logger,
 	}
 	var producer interfaces.KafkaProducerClient

--- a/kafka/kafka_producer.go
+++ b/kafka/kafka_producer.go
@@ -40,9 +40,23 @@ type Producer struct {
 }
 
 // NewProducer for creating a new Producer instance
-func NewProducer(config *viper.Viper, logger *log.Logger, clientOrNil ...interfaces.KafkaProducerClient) (*Producer, error) {
+func NewProducer(
+	config *viper.Viper,
+	logger *log.Logger,
+	clientOrNil ...interfaces.KafkaProducerClient,
+) (*Producer, error) {
+	return NewProducerWithPrefix(config, logger, "extensions.kafkaproducer", clientOrNil...)
+}
+
+// NewProducerWithPrefix for creating a new Producer instance
+func NewProducerWithPrefix(
+	config *viper.Viper,
+	logger *log.Logger,
+	prefix string,
+	clientOrNil ...interfaces.KafkaProducerClient,
+) (*Producer, error) {
 	q := &Producer{
-		Config: config,
+		Config: config.Sub(prefix),
 		Logger: logger,
 	}
 	var producer interfaces.KafkaProducerClient
@@ -54,12 +68,12 @@ func NewProducer(config *viper.Viper, logger *log.Logger, clientOrNil ...interfa
 }
 
 func (q *Producer) loadConfigurationDefaults() {
-	q.Config.SetDefault("extensions.kafkaproducer.brokers", "localhost:9941")
+	q.Config.SetDefault("brokers", "localhost:9941")
 }
 
 func (q *Producer) configure(producer interfaces.KafkaProducerClient) error {
 	q.loadConfigurationDefaults()
-	q.Brokers = q.Config.GetString("extensions.kafkaproducer.brokers")
+	q.Brokers = q.Config.GetString("brokers")
 	c := &kafka.ConfigMap{
 		"bootstrap.servers": q.Brokers,
 	}

--- a/kafka/kafka_producer_test.go
+++ b/kafka/kafka_producer_test.go
@@ -78,6 +78,26 @@ var _ = Describe("Producer Extension", func() {
 		})
 	})
 
+	Describe("Configuration Defaults", func() {
+		It("should configure defaults", func() {
+			cnf := viper.New()
+			cons, err := NewProducer(cnf, logger, mockProducer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cons.Config.GetString("brokers")).To(Equal("localhost:9092"))
+		})
+
+		It("should read a config with prefix", func() {
+			cnf := viper.New()
+			cnf.Set("brokers", "localhost:1234")
+			cons, err := NewProducerWithPrefix(cnf, logger, "test", mockProducer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cons.Config.GetString("brokers")).To(Equal("localhost:1234"))
+
+		})
+	})
+
 	XDescribe("[Integration]", func() {
 		Describe("Creating new producer", func() {
 			It("should return connected client", func() {

--- a/kafka/kafka_sarama_producer.go
+++ b/kafka/kafka_sarama_producer.go
@@ -58,8 +58,12 @@ func NewSyncProducerWithPrefix(
 	prefix string,
 	clientOrNil ...sarama.SyncProducer,
 ) (*SyncProducer, error) {
+	subconfig := config.Sub(prefix)
+	if subconfig == nil {
+		subconfig = viper.New()
+	}
 	s := &SyncProducer{
-		config:      config.Sub(prefix),
+		config:      subconfig,
 		logger:      logger,
 		kafkaConfig: kafkaConfig,
 	}

--- a/kafka/kafka_sarama_producer.go
+++ b/kafka/kafka_sarama_producer.go
@@ -41,12 +41,25 @@ type SyncProducer struct {
 }
 
 // NewSyncProducer creates a new kafka sync producer
-func NewSyncProducer(config *viper.Viper,
+func NewSyncProducer(
+	config *viper.Viper,
 	logger *log.Logger,
 	kafkaConfig *sarama.Config,
-	clientOrNil ...sarama.SyncProducer) (*SyncProducer, error) {
+	clientOrNil ...sarama.SyncProducer,
+) (*SyncProducer, error) {
+	return NewSyncProducerWithPrefix(config, logger, kafkaConfig, "extensions.kafkaproducer", clientOrNil...)
+}
+
+// NewSyncProducerWithPrefix creates a new kafka sync producer
+func NewSyncProducerWithPrefix(
+	config *viper.Viper,
+	logger *log.Logger,
+	kafkaConfig *sarama.Config,
+	prefix string,
+	clientOrNil ...sarama.SyncProducer,
+) (*SyncProducer, error) {
 	s := &SyncProducer{
-		config:      config,
+		config:      config.Sub(prefix),
 		logger:      logger,
 		kafkaConfig: kafkaConfig,
 	}
@@ -59,12 +72,12 @@ func NewSyncProducer(config *viper.Viper,
 }
 
 func (s *SyncProducer) loadConfigurationDefaults() {
-	s.config.SetDefault("extensions.kafkaproducer.brokers", "localhost:9092")
+	s.config.SetDefault("brokers", "localhost:9092")
 }
 
 func (s *SyncProducer) configure(producer sarama.SyncProducer) error {
 	s.loadConfigurationDefaults()
-	s.Brokers = s.config.GetString("extensions.kafkaproducer.brokers")
+	s.Brokers = s.config.GetString("brokers")
 	l := s.logger.WithFields(log.Fields{
 		"brokers": s.Brokers,
 	})

--- a/kafka/kafka_sarama_producer_test.go
+++ b/kafka/kafka_sarama_producer_test.go
@@ -92,6 +92,28 @@ var _ = XDescribe("SyncProducer Extension", func() {
 		})
 	})
 
+	Describe("Configuration Defaults", func() {
+		It("should configure defaults", func() {
+			cnf := viper.New()
+			c := sarama.NewConfig()
+			cons, err := NewSyncProducer(cnf, logger, c, mockProducer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cons.config.GetString("brokers")).To(Equal("localhost:9092"))
+		})
+
+		It("should read a config with prefix", func() {
+			cnf := viper.New()
+			cnf.Set("brokers", "localhost:1234")
+			c := sarama.NewConfig()
+			cons, err := NewSyncProducerWithPrefix(cnf, logger, c, "test", mockProducer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cons.config.GetString("brokers")).To(Equal("localhost:1234"))
+
+		})
+	})
+
 	XDescribe("[Integration]", func() {
 		Describe("Create a new producer", func() {
 			It("should return a connected client", func() {


### PR DESCRIPTION
My application uses several producers and consumer. Each one has a different configuration in Viper.

To make the Kafka extension usable to my context, I added a function on the producers/consumers that make able to introduce a prefix.

The changes I made are breaking changes. The following code will stop to work:

```
p = kafka.NewConsumer(v, l, nil)
p.Config.GetString("extensions.kafkaconsumer.offsetResetStrategy")
```
It need to be replaced to:
```
p = kafka.NewConsumer(v, l, nil)
p.Config.GetString("offsetResetStrategy")
```