### PR TITLE
Add method to create redis without viper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.8
 - 1.9
 - "1.10"
 sudo: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     ports:
       - "8585:5432"
     container_name: extensions_postgres_1
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   statsd:
     image: hopsoft/graphite-statsd
     ports:

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -34,6 +34,12 @@ import (
 	tredis "github.com/topfreegames/extensions/tracing/redis"
 )
 
+// ClientConfig holds the input configs for a client.
+type ClientConfig struct {
+	URL               string
+	ConnectionTimeout int
+}
+
 // Client identifies uniquely one redis client with a pool of connections
 type Client struct {
 	Client       interfaces.RedisClient
@@ -48,6 +54,14 @@ type TraceWrapper struct{}
 // WithContext is a wrapper for returning a client with context
 func (t *TraceWrapper) WithContext(ctx context.Context, c interfaces.RedisClient) interfaces.RedisClient {
 	return c.WithContext(ctx)
+}
+
+// NewClientFromConfig creates a Client with a ClientConfig.
+func NewClientFromConfig(config *ClientConfig, ifaces ...interface{}) (*Client, error) {
+	viperConfig := viper.New()
+	viperConfig.Set("prefix.url", config.URL)
+	viperConfig.Set("prefix.connectionTimeout", config.ConnectionTimeout)
+	return NewClient("prefix", viperConfig, ifaces...)
 }
 
 // NewClient creates and returns a new redis client based on the given settings


### PR DESCRIPTION
This PR adds the method `NewClientFromConfig()` to Redis, so a user can create a client without Viper.