### PR TITLE
feat(pg): add connection options

### DIFF
--- a/pg/pg.go
+++ b/pg/pg.go
@@ -24,6 +24,7 @@ package pg
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -105,6 +106,15 @@ func (c *Client) Connect(prefix string, db interfaces.DB) error {
 	port := c.Config.GetInt(fmt.Sprintf("%s.port", prefix))
 	poolSize := c.Config.GetInt(fmt.Sprintf("%s.poolSize", prefix))
 	maxRetries := c.Config.GetInt(fmt.Sprintf("%s.maxRetries", prefix))
+	sslMode := c.Config.GetString(fmt.Sprintf("%s.sslMode", prefix))
+
+	var tlsConfig *tls.Config
+	switch sslMode {
+	case "allow", "prefer", "require":
+		tlsConfig = &tls.Config{InsecureSkipVerify: true}
+	default:
+		tlsConfig = nil
+	}
 
 	c.Options = &pg.Options{
 		Addr:       fmt.Sprintf("%s:%d", host, port),
@@ -113,6 +123,64 @@ func (c *Client) Connect(prefix string, db interfaces.DB) error {
 		Database:   database,
 		PoolSize:   poolSize,
 		MaxRetries: maxRetries,
+		TLSConfig:  tlsConfig,
+	}
+
+	// Default is 5 seconds
+	dialTimeout := c.Config.GetDuration(fmt.Sprintf("%s.dialTimeout", prefix))
+	if dialTimeout > 0 {
+		c.Options.DialTimeout = dialTimeout
+	}
+	readTimeout := c.Config.GetDuration(fmt.Sprintf("%s.readTimeout", prefix))
+	if readTimeout > 0 {
+		c.Options.ReadTimeout = readTimeout
+	}
+	writeTimeout := c.Config.GetDuration(fmt.Sprintf("%s.writeTimeout", prefix))
+	if writeTimeout > 0 {
+		c.Options.WriteTimeout = writeTimeout
+	}
+	// Default is 5 minutes
+	idleTimeout := c.Config.GetDuration(fmt.Sprintf("%s.idleTimeout", prefix))
+	if idleTimeout > 0 {
+		c.Options.IdleTimeout = idleTimeout
+	}
+	// Default is 1 minute, -1 disables idle connections reaper
+	idleCheckFrequency := c.Config.GetDuration(fmt.Sprintf("%s.idleCheckFrequency", prefix))
+	if idleCheckFrequency > 0 || idleCheckFrequency == -1 {
+		c.Options.IdleCheckFrequency = idleCheckFrequency
+	}
+	// Default is 30 seconds if ReadTimeOut is not defined, otherwise,
+	// ReadTimeout + 1 second.
+	poolTimeout := c.Config.GetDuration(fmt.Sprintf("%s.poolTimeout", prefix))
+	if poolTimeout > 0 {
+		c.Options.PoolTimeout = poolTimeout
+	}
+	// Default is to not close aged connections.
+	maxConnAge := c.Config.GetDuration(fmt.Sprintf("%s.maxConnAge", prefix))
+	if maxConnAge > 0 {
+		c.Options.MaxConnAge = maxConnAge
+	}
+
+	minIdleConns := c.Config.GetInt(fmt.Sprintf("%s.minIdleConns", prefix))
+	if minIdleConns > 0 {
+		c.Options.MinIdleConns = minIdleConns
+	}
+
+	retryStatementTimeout := c.Config.GetBool(fmt.Sprintf("%s.retryStatementTimeout", prefix))
+	if retryStatementTimeout {
+		c.Options.RetryStatementTimeout = retryStatementTimeout
+	}
+
+	// Default is 250 milliseconds; -1 disables backoff.
+	minRetryBackoff := c.Config.GetDuration(fmt.Sprintf("%s.minRetryBackoff", prefix))
+	if minRetryBackoff > 0 || minRetryBackoff == -1 {
+		c.Options.MinRetryBackoff = minRetryBackoff
+	}
+
+	// Default is 4 seconds; -1 disables backoff.
+	maxRetryBackoff := c.Config.GetDuration(fmt.Sprintf("%s.maxRetryBackoff", prefix))
+	if maxRetryBackoff > 0 || maxRetryBackoff == -1 {
+		c.Options.MaxRetryBackoff = maxRetryBackoff
 	}
 
 	if db == nil {
@@ -162,7 +230,7 @@ func (c *Client) WaitForConnection(timeout int) error {
 	}
 }
 
-//Cleanup closes PG connection
+// Cleanup closes PG connection
 func (c *Client) Cleanup() error {
 	err := c.Close()
 	return err


### PR DESCRIPTION
Added multiple connections options exposed by go-pg but not in extensions. Some of these are necessary for the applicaiton to configure like sslMode and timeout handling idle connections. The code adds options to read from viper input config and map to `pg.Options` struct if they are set to a valid value - otherwise use the default:

Usage example in application:

```yaml
extensions:
  pg:
    sslMode: "require"
```

### SSL Mode

```go
	sslMode := c.Config.GetString(fmt.Sprintf("%s.sslMode", prefix))

	var tlsConfig *tls.Config
	switch sslMode {
	case "allow", "prefer", "require":
		tlsConfig = &tls.Config{InsecureSkipVerify: true}
	default:
		tlsConfig = nil
	}
```

### Timeouts

```go
	// Default is 5 seconds
	dialTimeout := c.Config.GetDuration(fmt.Sprintf("%s.dialTimeout", prefix))
	if dialTimeout > 0 {
		c.Options.DialTimeout = dialTimeout
	}
	readTimeout := c.Config.GetDuration(fmt.Sprintf("%s.readTimeout", prefix))
	if readTimeout > 0 {
		c.Options.ReadTimeout = readTimeout
	}
	writeTimeout := c.Config.GetDuration(fmt.Sprintf("%s.writeTimeout", prefix))
	if writeTimeout > 0 {
		c.Options.WriteTimeout = writeTimeout
	}
	// Default is 5 minutes
	idleTimeout := c.Config.GetDuration(fmt.Sprintf("%s.idleTimeout", prefix))
	if idleTimeout > 0 {
		c.Options.IdleTimeout = idleTimeout
	}

	retryStatementTimeout := c.Config.GetBool(fmt.Sprintf("%s.retryStatementTimeout", prefix))
	if retryStatementTimeout {
		c.Options.RetryStatementTimeout = retryStatementTimeout
	}

	// Default is 250 milliseconds; -1 disables backoff.
	minRetryBackoff := c.Config.GetDuration(fmt.Sprintf("%s.minRetryBackoff", prefix))
	if minRetryBackoff > 0 || minRetryBackoff == -1 {
		c.Options.MinRetryBackoff = minRetryBackoff
	}

	// Default is 4 seconds; -1 disables backoff.
	maxRetryBackoff := c.Config.GetDuration(fmt.Sprintf("%s.maxRetryBackoff", prefix))
	if maxRetryBackoff > 0 || maxRetryBackoff == -1 {
		c.Options.MaxRetryBackoff = maxRetryBackoff
	}
```

### Connection Pool Handling

```go
	// Default is 1 minute, -1 disables idle connections reaper
	idleCheckFrequency := c.Config.GetDuration(fmt.Sprintf("%s.idleCheckFrequency", prefix))
	if idleCheckFrequency > 0 || idleCheckFrequency == -1 {
		c.Options.IdleCheckFrequency = idleCheckFrequency
	}
	// Default is 30 seconds if ReadTimeOut is not defined, otherwise,
	// ReadTimeout + 1 second.
	poolTimeout := c.Config.GetDuration(fmt.Sprintf("%s.poolTimeout", prefix))
	if poolTimeout > 0 {
		c.Options.PoolTimeout = poolTimeout
	}
	// Default is to not close aged connections.
	maxConnAge := c.Config.GetDuration(fmt.Sprintf("%s.maxConnAge", prefix))
	if maxConnAge > 0 {
		c.Options.MaxConnAge = maxConnAge
	}

	minIdleConns := c.Config.GetInt(fmt.Sprintf("%s.minIdleConns", prefix))
	if minIdleConns > 0 {
		c.Options.MinIdleConns = minIdleConns
	}
```